### PR TITLE
adding klotho to devops section

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [OpenStack](https://www.openstack.org/) - Open source software for building private and public clouds.
     * [pyinfra](https://github.com/Fizzadar/pyinfra) - A versatile CLI tools and python libraries to automate infrastructure.
     * [saltstack](https://github.com/saltstack/salt) - Infrastructure automation and management system.
+    * [klotho](https://github.com/klothoplatform/klotho) - A CLI tool for transforming plain Python code to deployable cloud native code.
+
 * SSH-style Deployment
     * [cuisine](https://github.com/sebastien/cuisine) - Chef-like functionality for Fabric.
     * [fabric](https://github.com/fabric/fabric) - A simple, Pythonic tool for remote execution and deployment.


### PR DESCRIPTION
## What is this Python project?
Klotho
Describe features.
     A CLI tool for transforming plain Python code to deployable cloud native code. It introduces klotho annotations that transform code to execution units (lambdas, fargate, kubernetes), persist ORMs like SQLAlchemy, and more

## What's the difference between this Python project and similar ones?
As far as we know there are no similar projects. The closest one would be Chalice 

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
